### PR TITLE
fix(parser): Fix `getImageDataAtSecond` implementation which seemingl…

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -127,7 +127,7 @@ export class BIFParser {
 
     // since frames are defined at an interval of `this.framewiseSeparation`,
     // we need to convert the time into an appropriate frame number.
-    const frameNumber = Math.ceil((second * 1000) / this.framewiseSeparation);
+    const frameNumber = Math.floor(second / (this.framewiseSeparation / 1000));
 
     const frame = this.bifIndex[frameNumber];
 


### PR DESCRIPTION
…y did not make sense…

[Probably a good time to create tests…]

Given: `const frameNumber = Math.floor(second / (this.framewiseSeparation / 1000));`

A `bif` file with a `10` second `framewiseSeparation`.

```js
this.framewiseSeparation = 10000;

Math.floor(0 / (this.framewiseSeparation / 1000)); // frame 0
Math.floor(9 / (this.framewiseSeparation / 1000)); // frame 0
Math.floor(10 / (this.framewiseSeparation / 1000)); // frame 1
Math.floor(19 / (this.framewiseSeparation / 1000)); // frame 1
Math.floor(20 / (this.framewiseSeparation / 1000)); // frame 2
```

A `bif` file with a `3` second `framewiseSeparation`.

```js
this.framewiseSeparation = 3000;

Math.floor(0 / (this.framewiseSeparation / 1000)); // frame 0
Math.floor(9 / (this.framewiseSeparation / 1000)); // frame 3
Math.floor(10 / (this.framewiseSeparation / 1000)); // frame 3
Math.floor(19 / (this.framewiseSeparation / 1000)); // frame 6
Math.floor(20 / (this.framewiseSeparation / 1000)); // frame 6
```

A `bif` file with a `1` second `framewiseSeparation`.

```js
this.framewiseSeparation = 1000;

Math.floor(0 / (this.framewiseSeparation / 1000)); // frame 0
Math.floor(9 / (this.framewiseSeparation / 1000)); // frame 9
Math.floor(10 / (this.framewiseSeparation / 1000)); // frame 10
Math.floor(19 / (this.framewiseSeparation / 1000)); // frame 19
Math.floor(20 / (this.framewiseSeparation / 1000)); // frame 20
```

---

__TLDR__: Given a `bifIndex` that is separated by `10` second intervals, we are going to assume that the first `9` seconds of playback will pull in the first image frame.

Regardless if this is the ideal implementation, it should fix the issue of pulling in dead frames…

Current:
```js
this.framewiseSeparation = 10000;

Math.ceil((0 * 1000) / this.framewiseSeparation)); // frame 0
Math.ceil((9 * 1000) / this.framewiseSeparation)); // frame 1
Math.ceil((10 * 1000) / this.framewiseSeparation)); // frame 1
Math.ceil((19 * 1000) / this.framewiseSeparation)); // frame 2
Math.ceil((20 * 1000) / this.framewiseSeparation)); // frame 2
```

Comparing this with the fixed example above makes the current implementation make absolutely no sense.

_There is mixed feelings on what second should pull up what image, this PR isn't meant to deal with the scenario of __if__ second `1` should pull up the frame `2`… (because you will eventually see that)_